### PR TITLE
Making errorhandler

### DIFF
--- a/src/main/java/com/backendconnect/infra/exceptions/ErrorHandler.java
+++ b/src/main/java/com/backendconnect/infra/exceptions/ErrorHandler.java
@@ -1,0 +1,27 @@
+package com.backendconnect.infra.exceptions;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ErrorHandler {
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity handleEntityNotFound(){
+        return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity handleMethodArgumentNotValid(MethodArgumentNotValidException ex){
+        var errors = ex.getFieldErrors();
+        return ResponseEntity.badRequest().body(errors.stream().map(ErrorData::new).toList());
+    }
+    private record ErrorData(String field, String message) {
+        public ErrorData(FieldError error){
+            this(error.getField(), error.getDefaultMessage());
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `ErrorHandler` class to handle exceptions in the backend. The class uses Spring's `@RestControllerAdvice` to provide centralized exception handling for the application, improving error management and response consistency.

Exception handling improvements:

* [`src/main/java/com/backendconnect/infra/exceptions/ErrorHandler.java`](diffhunk://#diff-b264e9b1a2259b95af203091d9b8c93a339cbc8c146e3b9b8c9da38b73ccb1fdR1-R27): Added a new `ErrorHandler` class with methods to handle `EntityNotFoundException` and `MethodArgumentNotValidException`, returning appropriate HTTP responses for each.