### PR TITLE
making Delete logic

### DIFF
--- a/src/main/java/com/backendconnect/controller/TopicController.java
+++ b/src/main/java/com/backendconnect/controller/TopicController.java
@@ -56,7 +56,7 @@ public class TopicController {
 
     @GetMapping("/{id}")
     public ResponseEntity<Object> getTopic(@PathVariable long id) {
-        Optional<Topic> topic = topicRepository.findById(id);
+        Optional<Topic> topic = topicRepository.getRefenceById(id);
         if (topic.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -65,12 +65,23 @@ public class TopicController {
 
     @PutMapping("/{id}")
     public ResponseEntity<Object> updateTopic(@PathVariable long id, @RequestBody TopicRequest topicRequest) {
-        Optional<Topic> topic = topicRepository.findById(id);
-        if (topic.isEmpty()) {
-            return ResponseEntity.notFound().build();
+        Optional<Topic> topic = topicRepository.getRefenceById(id);
+        if (topic.isPresent()) {
+            topic.get().update(topicRequest);
+            topicRepository.save(topic.get());
+            return ResponseEntity.ok(new TopicInfo(topic.get()));
         }
-        topic.get().update(topicRequest);
-        topicRepository.save(topic.get());
-        return ResponseEntity.ok(new TopicInfo(topic.get()));
+        return ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Object> deleteTopic(@PathVariable long id) {
+        Optional<Topic> topic = topicRepository.getRefenceById(id);
+        if (topic.isPresent()) {
+            topic.get().delete();
+            topicRepository.save(topic.get());
+            return ResponseEntity.ok(new TopicInfo(topic.get()));
+        }
+        return ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/com/backendconnect/domain/topic/TopicRepository.java
+++ b/src/main/java/com/backendconnect/domain/topic/TopicRepository.java
@@ -10,8 +10,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TopicRepository extends JpaRepository<Topic, Long> {
-    @Query("SELECT t FROM Topic t WHERE t.course = :courseId AND YEAR(t.createdAt) = :year ORDER BY t.createdAt DESC")
+    @Query("SELECT t FROM Topic t WHERE t.course = :courseId AND YEAR(t.createdAt) = :year  AND t.status = true ORDER BY t.createdAt DESC")
     List<Topic> findByCourseAndYear(long courseId, int year, Pageable pageable);
+
     Optional<Topic> findByTitleAndMessage(String title, String message);
+
+    @Query("SELECT t FROM Topic t WHERE t.status = true AND t.id = :id")
+    Optional<Topic> getRefenceById(long id);
+
+    @Query("SELECT t FROM Topic t WHERE t.status = true ORDER BY t.id DESC")
     Page<Topic> findAllByOrderByIdDesc(Pageable pageable);
 }


### PR DESCRIPTION
This pull request includes several changes to the `TopicController` and `TopicRepository` classes in the backend. The changes aim to improve the handling of topics by adding new methods and modifying existing ones to ensure only active topics are considered.

### Changes to `TopicController`:

* Replaced `findById` with `getRefenceById` in the `getTopic` method to fetch only active topics.
* Updated the `updateTopic` method to use `getRefenceById`, and added logic to update and save the topic if present.
* Added a new `deleteTopic` method to delete a topic by its ID, ensuring only active topics are considered.

### Changes to `TopicRepository`:

* Modified the `findByCourseAndYear` query to include a condition for active topics.
* Added a new query method `getRefenceById` to fetch active topics by ID.
* Added a new query method to fetch all active topics ordered by ID in descending order.